### PR TITLE
Use ERB, not SCSS for resolving image_path.

### DIFF
--- a/vendor/assets/stylesheets/jcrop.css.erb
+++ b/vendor/assets/stylesheets/jcrop.css.erb
@@ -5,7 +5,7 @@
 {
 	font-size: 0px;
 	position: absolute;
-	background: white url(image-path('jcrop/Jcrop.gif')) top left repeat;
+	background: white url(<%=image_path('jcrop/Jcrop.gif')%>) top left repeat;
 }
 .jcrop-vline { height: 100%; width: 1px !important; }
 .jcrop-hline { width: 100%; height: 1px !important; }


### PR DESCRIPTION
All of the asset helpers are available from the erb templating engine, so use that when resolving the image_path. That way any project can benefit from jcrop-rails, not just those using scss.
